### PR TITLE
fix: expose package entrypoint for neutral bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,13 @@
   "homepage": "https://github.com/OmniacDev/MCBE-IPC",
   "type": "module",
   "main": "dist/ipc.js",
+  "exports": {
+    ".": {
+      "types": "./dist/ipc.d.ts",
+      "import": "./dist/ipc.js",
+      "default": "./dist/ipc.js"
+    }
+  },
   "types": "dist/ipc.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
Add an `exports` entry for the package root so `mcbe-ipc` can be resolved by bundlers targeting the `neutral` platform.

Using `exports` follows the modern standard for defining package entry points. The existing `main` and `types` fields are preserved for compatibility.

References:

- https://rolldown.rs/reference/InputOptions.resolve
- https://nodejs.org/api/packages.html